### PR TITLE
Register response creation route

### DIFF
--- a/bulletin_board/board/urls.py
+++ b/bulletin_board/board/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path('responses/<int:pk>/accept/', accept_response, name='accept_response'),
     path('responses/<int:pk>/reject/', reject_response, name='reject_response'),
     path('responses/<int:pk>/toggle/', response_toggle_view, name='response_toggle'),
+    path('post/<int:pk>/response/', views.response_create, name='response_create'),
     path('register/', register_view, name='register'),
     path('confirm/', confirm_email_view, name='confirm_email'),
     path('account/', profile_view, name='account'),


### PR DESCRIPTION
## Summary
- add a URL pattern to expose the response creation view so the post detail form resolves correctly

## Testing
- python bulletin_board/manage.py check *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d155ef69c8832b991e6cfe33988f79